### PR TITLE
Fix NPE in HugeMushroomSpecies#rot (Closes #47)

### DIFF
--- a/src/main/java/com/dtteam/dynamictreesplus/tree/HugeMushroomSpecies.java
+++ b/src/main/java/com/dtteam/dynamictreesplus/tree/HugeMushroomSpecies.java
@@ -459,12 +459,16 @@ public class HugeMushroomSpecies extends Species {
 
     @Override
     public boolean rot(LevelAccessor level, BlockPos pos, int neighborCount, int radius, int fertility, RandomSource random, boolean rapid, boolean growLeaves) {
-        int maxBranchRotRadius = Services.CONFIG.getIntConfig(IConfigHelper.MAX_BRANCH_ROT_RADIUS);
+
+        Integer configValue = Services.CONFIG.getIntConfig(IConfigHelper.MAX_BRANCH_ROT_RADIUS);
+        final int maxBranchRotRadius = configValue != null ? configValue : 0;
+
         if (rapid || maxBranchRotRadius != 0 && radius <= maxBranchRotRadius) {
             BranchBlock branch = TreeHelper.getBranch(level.getBlockState(pos));
             if (branch != null) {
                 branch.rot(level, pos);
             }
+
             this.postRot(new PostRotContext(level, pos, this, radius, neighborCount, fertility, rapid));
             return true;
         }


### PR DESCRIPTION
This PR resolves #47 by preventing a `NullPointerException` during world generation in `HugeMushroomSpecies#rot`.

`Services.CONFIG.getIntConfig(MAX_BRANCH_ROT_RADIUS)` may return `null` if the config entry is missing or not initialized. The previous implementation relied on implicit unboxing, which caused a crash during feature placement.

This change replaces unsafe auto-unboxing with an explicit null check and a safe default value of 0, ensuring worldgen remains stable even when the config entry is absent.

Impact
- Fixes worldgen crash during feature placement
- No behavioral change when config is properly defined
- Minimal, localized change with no API impact

Closes #47.